### PR TITLE
service: use canonical path when searching configs

### DIFF
--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -88,8 +88,8 @@ export class TypeScriptService {
         if (typeCheck) {
             const { normalizedFileNames } = config;
             const languageService = this.getLanguageService(config, transpileOptions);
-
-            if (normalizedFileNames.has(filePath)) {
+            const { getCanonicalFileName } = baseHost;
+            if (normalizedFileNames.has(getCanonicalFileName(filePath))) {
                 // service includes our file, so use it to transpile
                 return this.transpileUsingLanguageService(filePath, languageService, baseHost);
             }


### PR DESCRIPTION
done mainly for Windows, where paths are case insensitive.