### PR TITLE
feat(esm): implement @ts-tools/esm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ Several packages to assist [TypeScript](https://www.typescriptlang.org/) develop
 
 ## Packages
 
-- **[@ts-tools/node](https://github.com/AviVahl/ts-tools/tree/main/packages/node)** - TypeScript support for Node.js. Allows running `.ts`/`.tsx` files directly from source.
+- **[@ts-tools/node](https://github.com/AviVahl/ts-tools/tree/main/packages/node)** - TypeScript support for Node.js. Registers a `require.extensions` (CommonJS) hook, allowing execution of `.ts`/`.tsx` files directly from source.
 
 - **[@ts-tools/webpack-loader](https://github.com/AviVahl/ts-tools/tree/main/packages/webpack-loader)** - TypeScript loader for webpack.
 
 - **[@ts-tools/transpile](https://github.com/AviVahl/ts-tools/tree/main/packages/transpile)** - TypeScript transpilation helpers.
 
 - **[@ts-tools/robotrix](https://github.com/AviVahl/ts-tools/tree/main/packages/robotrix)** - Useful TypeScript transpilation transformers.
+
+- **[@ts-tools/esm](https://github.com/AviVahl/ts-tools/tree/main/packages/esm)** - TypeScript support for Node.js. Exposes a loader (ESM), allowing execution of `.ts`/`.tsx` files directly from source.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,6 +215,10 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@ts-tools/esm": {
+      "resolved": "packages/esm",
+      "link": true
+    },
     "node_modules/@ts-tools/fixtures": {
       "resolved": "packages/fixtures",
       "link": true
@@ -3123,6 +3127,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/esm": {
+      "name": "@ts-tools/esm",
+      "version": "3.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0"
+      }
+    },
     "packages/fixtures": {
       "name": "@ts-tools/fixtures",
       "version": "3.0.1",
@@ -3325,6 +3340,10 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@ts-tools/esm": {
+      "version": "file:packages/esm",
+      "requires": {}
     },
     "@ts-tools/fixtures": {
       "version": "file:packages/fixtures"

--- a/packages/esm/LICENSE
+++ b/packages/esm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Avi Vahl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/esm/README.md
+++ b/packages/esm/README.md
@@ -1,0 +1,68 @@
+# @ts-tools/esm
+
+[![npm version](https://img.shields.io/npm/v/@ts-tools/esm.svg)](https://www.npmjs.com/package/@ts-tools/esm)
+
+[TypeScript](https://www.typescriptlang.org/) support for [Node.js](https://nodejs.org/en/).
+
+This package exposes an [esm loader](https://nodejs.org/docs/latest-v16.x/api/esm.html#esm_loaders), adding support for running `.ts` and `.tsx` files directly from source, in native esm mode.
+
+Features:
+
+- Fast! Uses `ts.transpileModule`. Leaves type checking to other flows.
+- Searches for the closest `tsconfig.json`, and adjusts it as necessary for native esm execution.
+- Source maps work with Node's `--enable-source-maps`, and when setting breakpoints directly on `.ts/.tsx` sources.
+
+## Getting started
+
+Install the library as a dev dependency in an existing TypeScript project:
+
+```
+npm i @ts-tools/esm --save-dev
+```
+
+Usage with [Node.js](https://nodejs.org/en/):
+
+```
+node --experimental-loader @ts-tools/esm ./my-script.ts
+```
+
+## Default Loader
+
+`@ts-tools/esm` main entrypoint exposes the default loader, which searches for the closest `tsconfig.json`
+to the current working directory.
+
+If found, it is loaded and adjusted for direct esm execution.
+
+If a `tsconfig.json` file is not found, the following `compilerOptions` are used:
+```ts
+const defaultCompilerOptions: ts.CompilerOptions = {
+  module: ts.ModuleKind.ESNext,
+  target: ts.ScriptTarget.ES2020,
+  inlineSourceMap: true,
+  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+  jsx: ts.JsxEmit.React,
+}
+```
+
+## Custom Loader
+
+`@ts-tools/esm/lib` (notice the `/lib`) exposes a programmatic API, which can be used to create a custom loader:
+
+```ts
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createLoader, loadTsconfig } from '@ts-tools/esm/lib';
+
+const tsconfigPath = fileURLToPath(new URL('./my-custom-tsconfig.json', import.meta.url));
+
+const { resolve, getFormat, transformSource } = createLoader({
+  compilerOptions: loadTsconfig(tsconfigPath),
+  cwd: dirname(tsconfigPath),
+});
+
+export { resolve, getFormat, transformSource };
+```
+
+## License
+
+MIT

--- a/packages/esm/lib.d.ts
+++ b/packages/esm/lib.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/index.js';

--- a/packages/esm/package.json
+++ b/packages/esm/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@ts-tools/esm",
+  "version": "3.0.1",
+  "description": "TypeScript support for Node.js.",
+  "type": "module",
+  "types": "./dist/default-loader.d.ts",
+  "exports": {
+    ".": "./dist/default-loader.js",
+    "./lib": "./dist/index.js"
+  },
+  "peerDependencies": {
+    "typescript": ">=2.8.0"
+  },
+  "files": [
+    "dist",
+    "!dist/test",
+    "src",
+    "!*/tsconfig.{json,tsbuildinfo}",
+    "lib.d.ts"
+  ],
+  "engines": {
+    "node": ">=12"
+  },
+  "author": "Avi Vahl <avi.vahl@wix.com>",
+  "license": "MIT",
+  "repository": "https://github.com/AviVahl/ts-tools/tree/main/packages/esm",
+  "homepage": "https://github.com/AviVahl/ts-tools",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/esm/src/create-loader.ts
+++ b/packages/esm/src/create-loader.ts
@@ -1,0 +1,77 @@
+import { pathToFileURL, fileURLToPath } from 'url';
+import ts from 'typescript';
+
+const isTypescriptFile = (url: string) => url.endsWith('.ts') || url.endsWith('.tsx');
+
+/** @url https://nodejs.org/docs/latest-v16.x/api/esm.html#esm_resolve_specifier_context_defaultresolve */
+export type ResolveHook = (
+  specifier: string,
+  context: { parentURL: string; conditions: string[] },
+  defaultResolve: ResolveHook
+) => { url: string };
+
+/** @url https://nodejs.org/docs/latest-v16.x/api/esm.html#esm_getformat_url_context_defaultgetformat */
+export type FormatHook = (url: string, context: {}, defaultGetFormat: FormatHook) => { format: ModuleFormat };
+export type ModuleFormat = 'builtin' | 'commonjs' | 'json' | 'module' | 'wasm';
+
+/** @url https://nodejs.org/docs/latest-v16.x/api/esm.html#esm_transformsource_source_context_defaulttransformsource */
+export type TransformHook = (
+  source: string | SharedArrayBuffer | Uint8Array,
+  context: { url: string; format: ModuleFormat },
+  defaultTransformSource: TransformHook
+) => { source: string | SharedArrayBuffer | Uint8Array };
+
+export interface CreateLoaderOptions {
+  compilerOptions: ts.CompilerOptions;
+  cwd: string;
+}
+
+export function createLoader({ compilerOptions, cwd }: CreateLoaderOptions) {
+  const moduleResolutionCache = ts.createModuleResolutionCache(
+    cwd,
+    ts.sys.useCaseSensitiveFileNames ? (s) => s : (s) => s.toLowerCase(),
+    compilerOptions
+  );
+  const resolve: ResolveHook = (specifier, context, defaultResolve) => {
+    const { parentURL } = context;
+    if (parentURL !== undefined && isTypescriptFile(parentURL)) {
+      const { resolvedModule } = ts.resolveModuleName(
+        specifier,
+        fileURLToPath(parentURL),
+        compilerOptions,
+        ts.sys,
+        moduleResolutionCache
+      );
+
+      if (resolvedModule && resolvedModule.extension !== '.d.ts') {
+        return {
+          url: pathToFileURL(resolvedModule.resolvedFileName).href,
+        };
+      }
+    }
+
+    return defaultResolve(specifier, context, defaultResolve);
+  };
+
+  const getFormat: FormatHook = (url, context, defaultGetFormat) => {
+    return isTypescriptFile(url) ? { format: 'module' } : defaultGetFormat(url, context, defaultGetFormat);
+  };
+
+  const transformSource: TransformHook = (source, context, defaultTransformSource) => {
+    const { url } = context;
+
+    return isTypescriptFile(url)
+      ? {
+          source: ts.transpileModule(source.toString(), {
+            fileName: fileURLToPath(url),
+            compilerOptions,
+          }).outputText,
+        }
+      : defaultTransformSource(source, context, defaultTransformSource);
+  };
+  return {
+    resolve,
+    getFormat,
+    transformSource,
+  };
+}

--- a/packages/esm/src/default-loader.ts
+++ b/packages/esm/src/default-loader.ts
@@ -1,0 +1,19 @@
+import ts from 'typescript';
+import { createLoader } from './create-loader.js';
+import { loadTsconfig } from './load-tsconfig.js';
+
+const defaultCompilerOptions: ts.CompilerOptions = {
+  module: ts.ModuleKind.ESNext,
+  target: ts.ScriptTarget.ES2020,
+  inlineSourceMap: true,
+  moduleResolution: ts.ModuleResolutionKind.NodeJs,
+  jsx: ts.JsxEmit.React,
+};
+
+const cwd = process.cwd();
+const tsconfigPath = ts.findConfigFile(cwd, ts.sys.fileExists);
+const compilerOptions = tsconfigPath !== undefined ? loadTsconfig(tsconfigPath) : defaultCompilerOptions;
+
+const { resolve, getFormat, transformSource } = createLoader({ compilerOptions, cwd });
+
+export { resolve, getFormat, transformSource };

--- a/packages/esm/src/index.ts
+++ b/packages/esm/src/index.ts
@@ -1,0 +1,2 @@
+export * from './create-loader.js';
+export * from './load-tsconfig.js';

--- a/packages/esm/src/load-tsconfig.ts
+++ b/packages/esm/src/load-tsconfig.ts
@@ -1,0 +1,24 @@
+import { dirname } from 'path';
+import ts from 'typescript';
+
+/**
+ * loads a tsconfig file
+ * @returns adjusted compiler options (suitable for esm execution)
+ */
+
+export function loadTsconfig(tsconfigPath: string): ts.CompilerOptions {
+  const { options } = ts.parseJsonSourceFileConfigFileContent(
+    ts.readJsonConfigFile(tsconfigPath, ts.sys.readFile),
+    ts.sys,
+    dirname(tsconfigPath)
+  );
+  if (options.module === undefined || options.module < ts.ModuleKind.ES2015) {
+    options.module = ts.ModuleKind.ES2020;
+  }
+  options.inlineSourceMap = true;
+  options.sourceMap = options.inlineSources = undefined;
+  options.mapRoot = options.sourceRoot = undefined;
+  options.outDir = options.outFile = undefined;
+  options.noEmit = undefined;
+  return options;
+}

--- a/packages/esm/src/tsconfig.json
+++ b/packages/esm/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist",
+    "module": "es2020"
+  }
+}

--- a/packages/esm/test/esm-loader.unit.ts
+++ b/packages/esm/test/esm-loader.unit.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { dirname, join, sep } from 'path';
+import { platform } from 'os';
+import { spawnSync } from 'child_process';
+import Module from 'module';
+
+const require = Module.createRequire(import.meta.url);
+const fixturesRoot = dirname(require.resolve('@ts-tools/fixtures/package.json'));
+const nodeMajorVersion = parseInt(process.versions.node.split('.')[0]!, 10);
+
+export function runCommand(command: string): { output: string; exitCode: number } {
+  const [execName, ...args] = command.split(' ');
+  const { output, status: exitCode } = spawnSync(execName!, args);
+  return { output: output.join('\n'), exitCode: exitCode || 0 };
+}
+
+describe('using node --experimental-loader @ts-tools/esm <file>', function () {
+  this.timeout(5000);
+
+  describe('when tsconfig.json is found', () => {
+    it('allows using imports (with default interop)', () => {
+      const filePath = join(fixturesRoot, 'imports.ts');
+
+      const { output, exitCode } = runCommand(`node --experimental-loader @ts-tools/esm ${filePath}`);
+
+      expect(exitCode).to.equal(0);
+      expect(output).to.include(`Current platform is: ${platform()}`);
+      expect(output).to.include(`Path separator is: ${sep}`);
+    });
+
+    if (nodeMajorVersion >= 14) {
+      it('maps stack traces using source maps when specifying --enable-source-maps', () => {
+        const filePath = join(fixturesRoot, 'throwing.ts');
+
+        const { output, exitCode } = runCommand(
+          `node --experimental-loader @ts-tools/esm --enable-source-maps ${filePath}`
+        );
+
+        expect(exitCode).to.not.equal(0);
+        expect(output).to.include(`runMe (${filePath}:10:11)`);
+      });
+    }
+
+    it('does not throw on empty files', () => {
+      const filePath = join(fixturesRoot, 'empty.ts');
+
+      const { exitCode, output } = runCommand(`node --experimental-loader @ts-tools/esm ${filePath}`);
+
+      expect(exitCode, output).to.equal(0);
+    });
+  });
+});

--- a/packages/esm/test/tsconfig.json
+++ b/packages/esm/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../dist/test",
+    "module": "es2020",
+    "types": ["node", "mocha"]
+  },
+  "references": [
+    {
+      "path": "../src"
+    }
+  ]
+}

--- a/packages/node/test/node-extension.unit.ts
+++ b/packages/node/test/node-extension.unit.ts
@@ -12,7 +12,7 @@ export function runCommand(command: string): { output: string; exitCode: number 
   return { output: output.join('\n'), exitCode: exitCode || 0 };
 }
 
-describe('using node -r @ts-tools/node/r [file]', function () {
+describe('using node -r @ts-tools/node/r <file>', function () {
   this.timeout(5000);
 
   describe('when tsconfig.json is found', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "./tsconfig.base.json",
   "files": [],
   "references": [
+    { "path": "./packages/esm/src" },
+    { "path": "./packages/esm/test" },
+
     { "path": "./packages/node/src" },
     { "path": "./packages/node/test" },
 


### PR DESCRIPTION
native esm TypeScript support for usage with Node's `--experimental-loader` flag