### PR TITLE
refactor: turn on exactOptionalPropertyTypes

### DIFF
--- a/packages/esm/src/load-tsconfig.ts
+++ b/packages/esm/src/load-tsconfig.ts
@@ -19,9 +19,9 @@ export function loadTsconfig(tsconfigPath: string): ts.CompilerOptions {
     options.moduleResolution = ts.ModuleResolutionKind.Node16;
   }
   options.inlineSourceMap = true;
-  options.sourceMap = options.inlineSources = undefined;
-  options.mapRoot = options.sourceRoot = undefined;
-  options.outDir = options.outFile = undefined;
-  options.noEmit = undefined;
+  options.sourceMap = options.inlineSources = undefined!;
+  options.mapRoot = options.sourceRoot = undefined!;
+  options.outDir = options.outFile = undefined!;
+  options.noEmit = undefined!;
   return options;
 }

--- a/packages/node/src/node-extension.ts
+++ b/packages/node/src/node-extension.ts
@@ -128,9 +128,9 @@ export function createNodeExtension({
 
   // Ensure source maps get picked up by v8 inspector (vscode/chrome debuggers) and node's `--enable-source-maps`.
   compilerOptions.inlineSourceMap = true;
-  compilerOptions.sourceMap = compilerOptions.inlineSources = undefined;
-  compilerOptions.mapRoot = compilerOptions.sourceRoot = undefined;
-  compilerOptions.outDir = compilerOptions.outFile = undefined;
+  compilerOptions.sourceMap = compilerOptions.inlineSources = undefined!;
+  compilerOptions.mapRoot = compilerOptions.sourceRoot = undefined!;
+  compilerOptions.outDir = compilerOptions.outFile = undefined!;
 
   if (autoScriptTarget && (compilerOptions.target === undefined || compilerOptions.target < ts.ScriptTarget.ES2019)) {
     compilerOptions.target = ts.ScriptTarget.ES2019;

--- a/packages/transpile/src/transpile-cached.ts
+++ b/packages/transpile/src/transpile-cached.ts
@@ -36,7 +36,7 @@ export function transpileCached(options: ITranspileCachedOptions): ts.TranspileO
     mtime,
     tsVersion,
     outputText: transpiledOutput.outputText,
-    sourceMapText: transpiledOutput.sourceMapText,
+    sourceMapText: transpiledOutput.sourceMapText!,
     ...filterAffectsEmit(compilerOptions),
   });
 

--- a/packages/webpack-loader/src/typescript-loader.ts
+++ b/packages/webpack-loader/src/typescript-loader.ts
@@ -129,15 +129,15 @@ export const typescriptLoader: webpack.LoaderDefinition = function (source) {
 
   // we dont accept any user overrides of sourcemap configuration
   // instead, we force external sourcemaps (with inline sources) on/off based on webpack signals.
-  compilerOptions.sourceMap = compilerOptions.inlineSources = sourceMap;
-  compilerOptions.inlineSourceMap = compilerOptions.mapRoot = compilerOptions.sourceRoot = undefined;
+  compilerOptions.sourceMap = compilerOptions.inlineSources = sourceMap!;
+  compilerOptions.inlineSourceMap = compilerOptions.mapRoot = compilerOptions.sourceRoot = undefined!;
 
   // force declarations off, as we don't have .d.ts bundling.
   // output locations are irrelevant, as we bundle. this ensures source maps have proper relative paths.
   // noEmit will not give us any output, so force that off.
-  compilerOptions.declaration = compilerOptions.declarationMap = undefined;
-  compilerOptions.outDir = compilerOptions.out = compilerOptions.outFile = undefined;
-  compilerOptions.noEmit = compilerOptions.noEmitOnError = compilerOptions.emitDeclarationOnly = undefined;
+  compilerOptions.declaration = compilerOptions.declarationMap = undefined!;
+  compilerOptions.outDir = compilerOptions.out = compilerOptions.outFile = undefined!;
+  compilerOptions.noEmit = compilerOptions.noEmitOnError = compilerOptions.emitDeclarationOnly = undefined!;
 
   // caching
   const optionsScopedCachePath = cacheDirectoryPath
@@ -156,7 +156,7 @@ export const typescriptLoader: webpack.LoaderDefinition = function (source) {
   const transpileOptions = {
     fileName: resourcePath,
     compilerOptions,
-    transformers,
+    transformers: transformers!,
     reportDiagnostics: true,
   };
 

--- a/packages/webpack-loader/test/bundle-with-loader.ts
+++ b/packages/webpack-loader/test/bundle-with-loader.ts
@@ -24,7 +24,7 @@ export async function bundleWithLoader({
         {
           test: /\.tsx?$/,
           loader: '@ts-tools/webpack-loader',
-          options,
+          options: options!,
         },
       ],
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -87,7 +87,7 @@
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     "noUnusedLocals": true,                              /* Enable error reporting when local variables aren't read. */
     "noUnusedParameters": true,                          /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    "exactOptionalPropertyTypes": true,                  /* Interpret optional property types as written, rather than adding 'undefined'. */
     "noImplicitReturns": true,                           /* Enable error reporting for codepaths that do not explicitly return in a function. */
     "noFallthroughCasesInSwitch": true,                  /* Enable error reporting for fallthrough cases in switch statements. */
     "noUncheckedIndexedAccess": true,                    /* Add 'undefined' to a type when accessed using an index. */


### PR DESCRIPTION
and workaround ts/webpack apis not explicitly specifying `| undefined` to fields that actually allow it