### PR TITLE
feat(esm)!: use the new register(loader) pattern

### DIFF
--- a/packages/esm/README.md
+++ b/packages/esm/README.md
@@ -23,7 +23,7 @@ npm i @ts-tools/esm --save-dev
 Usage with [Node.js](https://nodejs.org/en/):
 
 ```
-node --loader @ts-tools/esm ./my-script.ts
+node --import @ts-tools/esm ./my-script.ts
 ```
 
 ## Default Loader

--- a/packages/esm/package.json
+++ b/packages/esm/package.json
@@ -4,7 +4,8 @@
   "description": "TypeScript support for Node.js.",
   "type": "module",
   "exports": {
-    ".": "./dist/default-loader.js",
+    ".": "./dist/register.js",
+    "./default-loader": "./dist/default-loader.js",
     "./lib": "./dist/index.js",
     "./package.json": "./package.json"
   },

--- a/packages/esm/src/register.ts
+++ b/packages/esm/src/register.ts
@@ -1,0 +1,3 @@
+import { register } from 'node:module';
+
+register(new URL('default-loader.js', import.meta.url));

--- a/packages/esm/src/test/esm-loader.test.ts
+++ b/packages/esm/src/test/esm-loader.test.ts
@@ -15,12 +15,12 @@ export function runCommand(command: string): { output: string; exitCode: number 
   return { output: stripAnsi(output.join('\n')), exitCode: exitCode || 0 };
 }
 
-describe('using node --loader @ts-tools/esm <file>', { timeout: 5_000 }, () => {
+describe('using node --import @ts-tools/esm <file>', { timeout: 5_000 }, () => {
   describe('when tsconfig.json is found', () => {
     it('allows using imports (with default interop)', () => {
       const filePath = join(fixturesRoot, 'esm/imports.mts');
 
-      const { output, exitCode } = runCommand(`node --loader @ts-tools/esm ${filePath}`);
+      const { output, exitCode } = runCommand(`node --import @ts-tools/esm ${filePath}`);
 
       equal(exitCode, 0, output);
       ok(output.includes(`Current platform is: ${platform()}`), output);
@@ -30,7 +30,7 @@ describe('using node --loader @ts-tools/esm <file>', { timeout: 5_000 }, () => {
     it('maps stack traces using source maps when specifying --enable-source-maps', () => {
       const filePath = join(fixturesRoot, 'esm/throwing.mts');
 
-      const { output, exitCode } = runCommand(`node --loader @ts-tools/esm --enable-source-maps ${filePath}`);
+      const { output, exitCode } = runCommand(`node --import @ts-tools/esm --enable-source-maps ${filePath}`);
 
       notEqual(exitCode, 0, output);
       ok(output.includes(`runMe (${filePath}:10:11)`), output);
@@ -39,7 +39,7 @@ describe('using node --loader @ts-tools/esm <file>', { timeout: 5_000 }, () => {
     it('does not throw on empty files', () => {
       const filePath = join(fixturesRoot, 'esm/empty.mts');
 
-      const { exitCode, output } = runCommand(`node --loader @ts-tools/esm ${filePath}`);
+      const { exitCode, output } = runCommand(`node --import @ts-tools/esm ${filePath}`);
 
       equal(exitCode, 0, output);
     });


### PR DESCRIPTION
`--loader` got deprecated. use the new recommended pattern: https://nodejs.org/api/module.html#enabling